### PR TITLE
Fixed reader bug, added possibility to filter unphysical cycles, etc

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -13,6 +13,7 @@ source:
   url: https://github.com/GES-compchem/{{ name }}/archive/refs/tags/{{ version }}.zip
 
 build:
+  noarch: python
   number: 0
 
 


### PR DESCRIPTION
Now reader does not skip last line of charge/discharge cycles. Total power and capacity are calculated from cumulative sum and not integral. The reader now automatically discards incomplete cycles and allows for choosing whether to discard unphysical cycles (efficiencies > 0).

MPT reader can now take a single string as input, in case the user wants to read just a single file.

Styling of the code has been fixed with black.