### PR TITLE
fixed index error bug for discarded cycles

### DIFF
--- a/echemsuite/cellcycling/read_input.py
+++ b/echemsuite/cellcycling/read_input.py
@@ -46,9 +46,7 @@ class CellCycling:
             list of indices to mask/hide
         """
         for i in hide_indices:
-            print(self._cycles[i]._hidden)
             self._cycles[i]._hidden = True
-            print(self._cycles[i]._hidden)
 
         self.get_numbers()
 


### PR DESCRIPTION
New bool `self._hidden` variable added to `Cycle` object. Defaults to `False`, is set to `True` when an unphysical cycle is detected, and can be set/unset via the `hide()` and `unhide()` functions.

All `CellCycling` iterators and calculators only work on cycles for which the `._hidden` variable is False.