### PR TITLE
added support for "alternative" GAMRY file version 

### DIFF
--- a/echemsuite/cellcycling/read_input.py
+++ b/echemsuite/cellcycling/read_input.py
@@ -654,10 +654,10 @@ def build_DTA_cycles(filelist, clean):
 
     for filepath in filelist:
 
-        print("Loading:", filepath, "\n")
-
         filename = path.basename(filepath)
         extension = path.splitext(filename)[1]
+
+        print("Loading:", filepath, "\n")
 
         if extension.lower() == ".dta":
 
@@ -692,18 +692,31 @@ def build_DTA_cycles(filelist, clean):
                 )
 
                 # renaming columns to standard format
-                data.rename(
-                    columns={
-                        "s": "Time (s)",
-                        "V vs. Ref.": "Voltage vs. Ref. (V)",
-                        "A": "Current (A)",
-                    },
-                    inplace=True,
-                )
+                if "V vs. Ref." in data.columns:
+                    data.rename(
+                        columns={
+                            "s": "Time (s)",
+                            "V vs. Ref.": "Voltage vs. Ref. (V)",
+                            "A": "Current (A)",
+                        },
+                        inplace=True,
+                    )
+
+                elif "V" in data.columns:
+                    data.rename(
+                        columns={"s": "Time (s)", "V": "Voltage vs. Ref. (V)", "A": "Current (A)",},
+                        inplace=True,
+                    )
 
                 time = data["Time (s)"]
                 voltage = data["Voltage vs. Ref. (V)"]
                 current = data["Current (A)"]
+
+                if halfcycle_type is None:
+                    if current[0] > 0:
+                        halfcycle_type = "charge"
+                    elif current[0] < 0:
+                        halfcycle_type = "discharge"
 
                 halfcycles.append(HalfCycle(time, voltage, current, halfcycle_type))
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "GES-echem-suite" %}
-{% set version = "0.1.18a" %}
+{% set version = "0.1.19a" %}
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name="GES-echem-suite",
-    version="0.1.18a",
+    version="0.1.19a",
     description="",
     long_description="",
     packages=["echemsuite"],


### PR DESCRIPTION
+ fallback determination of charge/discharge halfcycle

In some GAMRY experiments the "V vs Ref." column is simply called "V". Library now correctly "translates" also those types of file.

Also, if the file is lacking explicit "Step 1 Current (A)" line, determines the half-cycle from the first value of the current.

We should probably ge rid of the previous method ("Step 1 Current (A)") entirely at this point.